### PR TITLE
Focus text-editor of active panel. Fixes #13

### DIFF
--- a/lib/popup-view.coffee
+++ b/lib/popup-view.coffee
@@ -122,5 +122,5 @@ class PopupView extends View
     @destroyed = yes
     @detach()
     @subs.dispose()
-    if ($editor = $(atom.views.getView atom.workspace).find 'atom-text-editor:visible')
+    if ($editor = $(atom.views.getView atom.workspace).find 'atom-text-editor:visible pane.active')
       $editor.focus()


### PR DESCRIPTION
Added a small change that limits the search of the visible text editor element to the active panel when closing the popup. Fixes issue #13 